### PR TITLE
Update ssd1306.h for C++ projects

### DIFF
--- a/ssd1306.h
+++ b/ssd1306.h
@@ -1,6 +1,11 @@
 #ifndef _SSD1306_H_
 #define _SSD1306_H_
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* For uint(X)_t */
 #include <stdint.h>
 
@@ -100,7 +105,7 @@ void SSD1306_SetInverted( struct SSD1306_Device* DeviceHandle, bool Inverted );
 void SSD1306_SetHFlip( struct SSD1306_Device* DeviceHandle, bool On );
 void SSD1306_SetVFlip( struct SSD1306_Device* DeviceHandle, bool On );
 void SSD1306_DisplayOn( struct SSD1306_Device* DeviceHandle );
-void SSD1306_DisplayOff( struct SSD1306_Device* DeviceHandle ); 
+void SSD1306_DisplayOff( struct SSD1306_Device* DeviceHandle );
 void SSD1306_SetDisplayAddressMode( struct SSD1306_Device* DeviceHandle, SSD1306_AddressMode AddressMode );
 void SSD1306_Update( struct SSD1306_Device* DeviceHandle );
 void SSD1306_SetDisplayClocks( struct SSD1306_Device* DeviceHandle, uint32_t DisplayClockDivider, uint32_t OSCFrequency );
@@ -113,5 +118,9 @@ bool SSD1306_HWReset( struct SSD1306_Device* DeviceHandle );
 
 bool SSD1306_Init_I2C( struct SSD1306_Device* DeviceHandle, int Width, int Height, int I2CAddress, int ResetPin, WriteCommandProc WriteCommand, WriteDataProc WriteData, ResetProc Reset );
 bool SSD1306_Init_SPI( struct SSD1306_Device* DeviceHandle, int Width, int Height, int ResetPin, int CSPin, spi_device_handle_t SPIHandle, WriteCommandProc WriteCommand, WriteDataProc WriteData, ResetProc Reset );
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
I added `extern "C"` snippets to ssd1306.h.
It doesn't work in C++ projects without them.

When I use this repository before modification, I had an error below:
```
undefined reference to `SSD1306_Update(SSD1306_Device*)'
collect2: error: ld returned 1 exit status
```