### PR TITLE
Replace esp_panic.h to avoid compiler warnings

### DIFF
--- a/ssd1306_err.h
+++ b/ssd1306_err.h
@@ -2,7 +2,9 @@
 #define _SSD1306_ERR_H_
 
 #include <esp_log.h>
-#include <esp_panic.h>
+#include <esp_debug_helpers.h>
+#include <esp_private/panic_reason.h>
+
 
 #if CONFIG_SSD1306_ERROR_ABORT
     #define SSD1306_DoAbort( ) abort( )


### PR DESCRIPTION
Including `esp_panic.h` will generate a warning during compilation, since the file became deprecated. 
By replacing it with `esp_debug_helpers.h` and `esp_private/panic_reason.h`, the generation of warnings can be avoided. 