### PR TITLE
Fix build errors in newer esp-idf. Fixes #3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,21 @@
-set(COMPONENT_SRCDIRS ". fonts ifaces")
-set(COMPONENT_ADD_INCLUDEDIRS ".")
-register_component()
+idf_component_register(
+  SRCS
+  "ssd1306.c"
+  "ssd1306_font.c"
+  "ssd1306_draw.c"
+  "ifaces/default_if_i2c.c"
+  "ifaces/default_if_spi.c"
+  "fonts/font_droid_sans_fallback_11x13.c"
+  "fonts/font_droid_sans_fallback_15x17.c"
+  "fonts/font_droid_sans_fallback_24x28.c"
+  "fonts/font_droid_sans_mono_13x24.c"
+  "fonts/font_droid_sans_mono_16x31.c"
+  "fonts/font_droid_sans_mono_7x13.c"
+  "fonts/font_liberation_mono_13x21.c"
+  "fonts/font_liberation_mono_17x30.c"
+  "fonts/font_liberation_mono_9x15.c"
+  "fonts/font_tarable7seg_16x32.c"
+  "fonts/font_tarable7seg_32x64.c"
+
+  INCLUDE_DIRS "."
+)


### PR DESCRIPTION
Apparently the new IDF requires all source files to be listed, this fixes the build errors described in #3 