### PR TITLE
Add function to rotate display 180 degrees.

### DIFF
--- a/ssd1306.c
+++ b/ssd1306.c
@@ -75,6 +75,9 @@ static void SetCOMPinConfiguration( struct SSD1306_Device* DeviceHandle, uint32_
     SSD1306_WriteCommand( DeviceHandle, 
         ( ScanDir == COM_ScanDir_LR ) ? SSDCmd_Set_Display_VFlip_Off : SSDCmd_Set_Display_VFlip_On
     );
+    SSD1306_WriteCommand( DeviceHandle,
+        ( ScanDir == COM_ScanDir_LR ) ? SSDCmd_Set_Display_HFlip_Off : SSDCmd_Set_Display_HFlip_On
+    );
 }
 
 void SSD1306_SetContrast( struct SSD1306_Device* DeviceHandle, uint8_t Contrast ) {
@@ -193,6 +196,21 @@ bool SSD1306_HWReset( struct SSD1306_Device* DeviceHandle ) {
      * no error would have occurred during the non existant reset.
      */
     return true;
+}
+
+void SSD1306_Rotate180( struct SSD1306_Device* DeviceHandle ) {
+    NullCheck( DeviceHandle, return );
+    /* Behaviour unknown on full size displays, just return. */
+    if ( DeviceHandle->Height == 64 ) {
+        return;
+    }
+    if ( DeviceHandle->Rotated ) {
+        DeviceHandle->Rotated = false;
+        SetCOMPinConfiguration( DeviceHandle, COM_Disable_LR_Remap, COM_Pins_Sequential, COM_ScanDir_LR );
+    } else {
+        DeviceHandle->Rotated = true;
+        SetCOMPinConfiguration( DeviceHandle, COM_Enable_LR_Remap, COM_Pins_Sequential, COM_ScanDir_RL );
+    }
 }
 
 static bool SSD1306_Init( struct SSD1306_Device* DeviceHandle, int Width, int Height ) {

--- a/ssd1306.h
+++ b/ssd1306.h
@@ -92,6 +92,7 @@ struct SSD1306_Device {
     const struct SSD1306_FontDef* Font;
     bool FontForceProportional;
     bool FontForceMonospace;
+    bool Rotated;
 };
 
 void SSD1306_SetMuxRatio( struct SSD1306_Device* DeviceHandle, uint8_t Ratio );
@@ -110,6 +111,7 @@ void SSD1306_SetDisplayAddressMode( struct SSD1306_Device* DeviceHandle, SSD1306
 void SSD1306_Update( struct SSD1306_Device* DeviceHandle );
 void SSD1306_SetDisplayClocks( struct SSD1306_Device* DeviceHandle, uint32_t DisplayClockDivider, uint32_t OSCFrequency );
 void SSD1306_WriteRawData( struct SSD1306_Device* DeviceHandle, uint8_t* Data, size_t DataLength );
+void SSD1306_Rotate180( struct SSD1306_Device* DeviceHandle );
 
 void SSD1306_SetColumnAddress( struct SSD1306_Device* DeviceHandle, uint8_t Start, uint8_t End );
 void SSD1306_SetPageAddress( struct SSD1306_Device* DeviceHandle, uint8_t Start, uint8_t End );


### PR DESCRIPTION
Tested on 128x32 display.

I needed to add this as my build resulted in the display being orientated upside-down.

I am not sure what effect this has on 128x64 displays as I do not have one to test on.